### PR TITLE
Doh - correct config value used for blazy

### DIFF
--- a/app/Helpers/NxCodeHelper.php
+++ b/app/Helpers/NxCodeHelper.php
@@ -185,8 +185,8 @@ HTML;
         $text = self::embedYouTube($text);
         $text = self::spoilerTags($text);
         $text = MarkdownHelper::markdown($text);
-        if (false !== config('placeholder_image')) {
-            $text = self::lazyloadClass($text, config('placeholder_image'));
+        if (false !== config('nexus.placeholder_image')) {
+            $text = self::lazyloadClass($text, config('nexus.placeholder_image'));
         }
         $text = MentionHelper::highlightMentions($text);
 


### PR DESCRIPTION
now uses the correct value for the lazy loading placeholder image. 