### PR TITLE
Renamed 'status' to 'popname' to match profile screen

### DIFF
--- a/resources/views/activities/index.blade.php
+++ b/resources/views/activities/index.blade.php
@@ -27,7 +27,7 @@
                 <tr>
                     <th></th>
                     <th>Name</th>
-                    <th class="hidden-xs">Status</th>
+                    <th class="hidden-xs">Popname</th>
                     <th>Current Action</th>
                     <th>Last Active</th>
                 </tr>


### PR DESCRIPTION
Simple fix for a simple issue. 

Lazy coding day. 