### PR TITLE
Remove the topicjump cache when a topic changes

### DIFF
--- a/app/Events/TopicJumpCacheBecameDirty.php
+++ b/app/Events/TopicJumpCacheBecameDirty.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Events;
+
+use Illuminate\Broadcasting\Channel;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Broadcasting\PrivateChannel;
+use Illuminate\Broadcasting\PresenceChannel;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+
+class TopicJumpCacheBecameDirty
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    /**
+     * Create a new event instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        //
+    }
+
+    /**
+     * Get the channels the event should broadcast on.
+     *
+     * @return \Illuminate\Broadcasting\Channel|array
+     */
+    public function broadcastOn()
+    {
+        return new PrivateChannel('channel-name');
+    }
+}

--- a/app/Listeners/DeleteTopicJumpCache.php
+++ b/app/Listeners/DeleteTopicJumpCache.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Listeners;
+
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Queue\InteractsWithQueue;
+use App\Events\TopicJumpCacheBecameDirty;
+use Illuminate\Contracts\Queue\ShouldQueue;
+
+class DeleteTopicJumpCache
+{
+    /**
+     * Create the event listener.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        //
+    }
+
+    /**
+     * Handle the event.
+     *
+     * @param  TopicJumpCacheBecameDirty  $event
+     * @return void
+     */
+    public function handle(TopicJumpCacheBecameDirty $event)
+    {
+        Log::debug("Deleting TopicJump Cache");
+        Cache::forget('topicIndex');
+
+    }
+}

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -27,6 +27,9 @@ class EventServiceProvider extends ServiceProvider
         Registered::class => [
             SendEmailVerificationNotification::class,
         ],
+        'App\Events\TopicJumpCacheBecameDirty' => [
+            'App\Listeners\DeleteTopicJumpCache'
+        ]
     ];
 
     /**

--- a/app/Topic.php
+++ b/app/Topic.php
@@ -4,7 +4,9 @@ namespace App;
 
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Event;
 use Illuminate\Database\Eloquent\Model;
+use App\Events\TopicJumpCacheBecameDirty;
 use Illuminate\Database\Eloquent\SoftDeletes;
 
 class Topic extends Model
@@ -39,6 +41,11 @@ class Topic extends Model
                 }
             }
         });
+
+        // forget the topicjump cache when a topic changes, is created or destroyed
+        Topic::deleted(function () {event(new TopicJumpCacheBecameDirty());});
+        Topic::updated(function () {event(new TopicJumpCacheBecameDirty());});
+        Topic::created(function () {event(new TopicJumpCacheBecameDirty());});        
     }
     /**
      * returns the time of the most recent post


### PR DESCRIPTION
To keep the TopicJump menu's list of topics valid this removes the topicjump cache when a topic is created, removed, updated