### PR TITLE
add scope for verified users - limits user list to that

### DIFF
--- a/app/Http/Controllers/Nexus/UserController.php
+++ b/app/Http/Controllers/Nexus/UserController.php
@@ -31,7 +31,7 @@ class UserController extends Controller
     public function index(Request $request)
     {
         $users =  User::select('username', 'name', 'popname', 'latestLogin', 'totalPosts', 'totalVisits')
-            ->orderBy('username', 'asc')->get();
+            ->verified()->orderBy('username', 'asc')->get();
             ActivityHelper::updateActivity(
                 $request->user()->id,
                 "Viewing list of Users",

--- a/app/User.php
+++ b/app/User.php
@@ -246,7 +246,7 @@ class User extends Authenticatable implements MustVerifyEmail
         return $count;
     }
 
-       /**
+    /**
      * Present the user model.
      *
      * @return ViewModels\UserPresenter
@@ -254,5 +254,17 @@ class User extends Authenticatable implements MustVerifyEmail
     public function present()
     {
         return new UserPresenter($this);
+    }
+
+
+    /**
+     * exclude unverified users
+     *
+     * @param \Illuminate\Database\Eloquent\Builder $query
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    public function scopeVerified($query)
+    {
+        return $query->where('email_verified_at', '<>', null);
     }
 }

--- a/tests/Feature/UnverifiedUsersTest.php
+++ b/tests/Feature/UnverifiedUsersTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\User;
+use Carbon\Carbon;
+use Tests\TestCase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\DatabaseMigrations;
+
+class UnverifiedUsersTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * @test
+     */
+    public function whenAUserIsVerifiedTheyAreAddedToTheVerifiedUserList()
+    {
+        $unverifiedUser = factory(User::class)->create([
+           'email_verified_at' => null
+        ]);
+        $userCount = User::verified()->get()->count();
+
+        $unverifiedUser->email_verified_at = Carbon::now();
+        $unverifiedUser->save();
+        $newUserCount = User::verified()->get()->count();
+
+        $this->assertEquals($userCount + 1, $newUserCount);
+    }
+
+    /**
+     * @test
+     */
+    public function unverifiedUsersDoNotAppearInVerifiedUserList()
+    {
+        $unverifiedUser = factory(User::class)->create([
+           'email_verified_at' => null
+        ]);
+
+        $allUsers = User::verified()->get();
+
+        $count = $allUsers->where('id', $unverifiedUser->id)->count();
+
+        $this->assertEquals($count, 0);
+    }
+}


### PR DESCRIPTION
This adds a 'verified' scope to the user model to lists of users can be restricted to verified users if desired. 

The user list is then uses this scope to stop displaying unverified users.