### PR TITLE
Form class more strict about type conversion so setting false to 0

### DIFF
--- a/resources/views/topic/_edit.blade.php
+++ b/resources/views/topic/_edit.blade.php
@@ -12,8 +12,8 @@ $errorBag = 'topicUpdate' . $topic->id;
     )) 
 !!}
     {!! Form::hidden($formName . '[id]', $topic->id) !!}
-    {!! Form::hidden($formName . '[secret]', false) !!}  
-    {!! Form::hidden($formName. '[readonly]', false) !!}
+    {!! Form::hidden($formName . '[secret]', 0) !!}  
+    {!! Form::hidden($formName. '[readonly]', 0) !!}
 
 
     <div class="form-group">    

--- a/resources/views/topics/_create.blade.php
+++ b/resources/views/topics/_create.blade.php
@@ -5,8 +5,8 @@
     )) 
 !!}
 {!! Form::hidden("section_id", $section->id) !!}
-{!! Form::hidden("secret", false) !!}  
-{!! Form::hidden("readonly", false) !!}
+{!! Form::hidden("secret", 0) !!}  
+{!! Form::hidden("readonly", 0) !!}
 
 <div class="form-group">    
     {!! Form::label("title",'Title', ['class' => 'sr-only']) !!}

--- a/resources/views/users/_edit.blade.php
+++ b/resources/views/users/_edit.blade.php
@@ -46,7 +46,7 @@ Form::model($user, array(
 
 <div class="form-row">
     <div class="form-check">
-        {!! Form::hidden('private', false) !!}
+        {!! Form::hidden('private', 0) !!}
         {!! Form::checkbox('private', true, $user->private, ['class' => 'form-check-input', 'id' => 'private'])!!}
         {!! Form::label('private','Hide Email', ['class' => 'form-check-label']) !!}
     </div>
@@ -62,7 +62,7 @@ Form::model($user, array(
     </div>
     <div class="form-group col-12 col-md-6">
         <div class="form-check">
-            {!! Form::hidden('viewLatestPostFirst', false) !!}
+            {!! Form::hidden('viewLatestPostFirst', 0) !!}
             {!! Form::checkbox('viewLatestPostFirst', true, $user->viewLatestPostFirst, ['class' => 'form-check-input', 'id' => 'viewLatestPostFirst'])!!}
             {!! Form::label('viewLatestPostFirst', 'Show Latest Posts First', ['class' => 'form-check-label']) !!}
         </div>


### PR DESCRIPTION
Laravelcollective's form classes are more strict about casting values. 

This caused issues where a default value for checkboxes of 'false' we being set to an empty string rather than a 0. 

Effect was that new topics could not be created or users updated without having to check empty checkboxes which has been set to 'false' via a hidden variable. 

this is for https://github.com/christiancable/nexus5ive/issues/331