### PR TITLE
Cache section.latest_post attribute

### DIFF
--- a/app/Events/MostRecentPostForSectionBecameDirty.php
+++ b/app/Events/MostRecentPostForSectionBecameDirty.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Events;
+
+use Illuminate\Broadcasting\Channel;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Broadcasting\PresenceChannel;
+use Illuminate\Broadcasting\PrivateChannel;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class MostRecentPostForSectionBecameDirty
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    public $section_id;
+
+    /**
+     * Create a new event instance.
+     *
+     * @return void
+     */
+    public function __construct($section_id)
+    {
+        $this->section_id = $section_id;
+    }
+
+    /**
+     * Get the channels the event should broadcast on.
+     *
+     * @return \Illuminate\Broadcasting\Channel|array
+     */
+    public function broadcastOn()
+    {
+        return new PrivateChannel('channel-name');
+    }
+}

--- a/app/Http/Controllers/Nexus/SectionController.php
+++ b/app/Http/Controllers/Nexus/SectionController.php
@@ -69,7 +69,6 @@ class SectionController extends Controller
             'sections.moderator:id,username',
             'sections.sections',
             'topics.most_recent_post.author:id,username',
-            'sections.topics.posts:id,time'
         );
         
         ActivityHelper::updateActivity(

--- a/app/Listeners/DeleteSectionMostRecentPostCache.php
+++ b/app/Listeners/DeleteSectionMostRecentPostCache.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Listeners;
+
+use App\Section;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use App\Events\MostRecentPostForSectionBecameDirty;
+
+class DeleteSectionMostRecentPostCache
+{
+    /**
+     * Create the event listener.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        //
+    }
+
+    /**
+     * Handle the event.
+     *
+     * @param  object  $event
+     * @return void
+     */
+    public function handle(MostRecentPostForSectionBecameDirty $event)
+    {
+        Section::forgetMostRecentPostAttribute($event->section_id);
+    }
+}

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -30,6 +30,9 @@ class EventServiceProvider extends ServiceProvider
         'App\Events\TreeCacheBecameDirty' => [
             'App\Listeners\DeleteTreeCache'
         ],
+        'App\Events\MostRecentPostForSectionBecameDirty' => [
+            'App\Listeners\DeleteSectionMostRecentPostCache'
+        ],
         'App\Events\UserCreated' => [
             'App\Listeners\LogUnverifiedUser'
         ],

--- a/app/Section.php
+++ b/app/Section.php
@@ -6,6 +6,7 @@ use Illuminate\Support\Str;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Log;
 use App\Events\TreeCacheBecameDirty;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
 
@@ -168,7 +169,30 @@ class Section extends Model
     
     public function getMostRecentPostAttribute()
     {
-        $topicIDs = Topic::select('id')->where('section_id', $this->id)->get()->toArray();
+        $cacheKey = 'mostRecentPost' . $this->id;
+        $section_id = $this->id;
+
+        return Cache::rememberForever(
+            $cacheKey,
+            function () use ($section_id) {
+                return self::recalculateMostRecentPost($section_id);
+            }
+        );
+    }
+        
+    /**
+     * recalculateMostRecentPost
+     *
+     * @param mixed $section_id - ID of the section
+     * @return Post - the most recent post for the section or null
+     */
+    private static function recalculateMostRecentPost($section_id = null)
+    {
+        if (null === $section_id) {
+            return null;
+        }
+
+        $topicIDs = Topic::select('id')->where('section_id', $section_id)->get()->toArray();
         if (0 == count($topicIDs)) {
             return null;
         }

--- a/app/Section.php
+++ b/app/Section.php
@@ -179,7 +179,13 @@ class Section extends Model
             }
         );
     }
-        
+
+    public static function forgetMostRecentPostAttribute($section_id = null)
+    {
+        $cacheKey = 'mostRecentPost' . $section_id;
+        Cache::forget($cacheKey);
+    }
+
     /**
      * recalculateMostRecentPost
      *

--- a/app/Topic.php
+++ b/app/Topic.php
@@ -89,11 +89,9 @@ class Topic extends Model
         Topic::deleted(function () {
             event(new TreeCacheBecameDirty());
         });
-        Topic::updating(function ($topic) {
+        Topic::updated(function ($topic) {
             $original_section_id = $topic->getOriginal('section_id');
             event(new MostRecentPostForSectionBecameDirty($original_section_id));
-        });
-        Topic::updated(function ($topic) {
             event(new TreeCacheBecameDirty());
         });
         Topic::created(function () {

--- a/app/Topic.php
+++ b/app/Topic.php
@@ -2,12 +2,14 @@
 
 namespace App;
 
+use App\Section;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Log;
 use App\Events\TreeCacheBecameDirty;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use App\Events\MostRecentPostForSectionBecameDirty;
 
 /**
  * App\Topic
@@ -87,7 +89,11 @@ class Topic extends Model
         Topic::deleted(function () {
             event(new TreeCacheBecameDirty());
         });
-        Topic::updated(function () {
+        Topic::updating(function ($topic) {
+            $original_section_id = $topic->getOriginal('section_id');
+            event(new MostRecentPostForSectionBecameDirty($original_section_id));
+        });
+        Topic::updated(function ($topic) {
             event(new TreeCacheBecameDirty());
         });
         Topic::created(function () {

--- a/tests/Browser/SectionInfoTest.php
+++ b/tests/Browser/SectionInfoTest.php
@@ -8,6 +8,7 @@ use App\Topic;
 use App\Section;
 use Tests\DuskTestCase;
 use Laravel\Dusk\Browser;
+use Illuminate\Support\Facades\Artisan;
 use Illuminate\Foundation\Testing\DatabaseMigrations;
 
 class SectionInfoTest extends DuskTestCase
@@ -39,6 +40,9 @@ class SectionInfoTest extends DuskTestCase
         $this->anotherTopicInSubSection = factory(Topic::class)->create([
            'section_id' => $this->subSection->id
         ]);
+
+        // we cache the latest post info so clear the cache between tests
+        Artisan::call('cache:clear');
     }
 
     /**

--- a/tests/intergration/models/SectionTest.php
+++ b/tests/intergration/models/SectionTest.php
@@ -235,7 +235,6 @@ class SectionTest extends TestCase
      */
     public function latestPostReturnsMostRecentPostAsPostsAreRemoved()
     {
-
         /*
         GIVEN a section with topics, and a first and second post
         */
@@ -317,8 +316,9 @@ class SectionTest extends TestCase
                 'parent_id' => null,
                 'user_id' => $moderator->id
         ]);
-        $topic1->section_id = $section2->id;
-        $topic1->save();
+        $topic1->update([
+            'section_id' => $section2->id
+        ]);
 
         /*
         THEN the latest post for that section becomes null

--- a/tests/intergration/models/SectionTest.php
+++ b/tests/intergration/models/SectionTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Intergration\Models;
 
 use App\User;
+use App\Post;
 use App\Topic;
 use App\Section;
 use Tests\TestCase;
@@ -11,7 +12,7 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 class SectionTest extends TestCase
 {
     use RefreshDatabase;
-        
+
     /**
      * @test
      */
@@ -30,19 +31,19 @@ class SectionTest extends TestCase
                 'parent_id' => $mainmenu->id,
                 'user_id' => $user->id,
                 ]);
-        
+
         // AND some other sections
         factory(Section::class)
             ->create([
                 'parent_id' => $mainmenu->id,
                 'user_id' => $user->id,
                 ]);
-        
+
         $sectionCount = Section::all()->count();
 
         // WHEN that particular section is deleted
         $section->delete();
-        
+
         // THEN number of sections goes down by one
         $sectionCountAfterDeletion = Section::all()->count();
         $this->assertEquals($sectionCountAfterDeletion, $sectionCount-1);
@@ -50,13 +51,15 @@ class SectionTest extends TestCase
         // AND that particular section is soft deleted
         $this->assertTrue($section->trashed());
     }
-    
-    
+
+    /**
+     * @test
+     */
     public function deletingSectionSoftDeletesItsTopics()
     {
         // GIVEN we have a user
         $user = factory(User::class)->create();
-        
+
         // AND we have a section
         $section = factory(Section::class)
             ->create([
@@ -67,9 +70,9 @@ class SectionTest extends TestCase
         // AND that section has topics
         factory(Topic::class)->create(['section_id' => $section->id]);
         $topicsInSectionCount = $section->topics->count();
-                
+
         $topicCount = Topic::all()->count();
-    
+
         // WHEN we delete that section
         $section->delete();
 
@@ -77,19 +80,22 @@ class SectionTest extends TestCase
         // belonging to the original section
         $topicCountAfterDeletion = Topic::all()->count();
         $this->assertEquals($topicCount - $topicsInSectionCount, $topicCountAfterDeletion);
-        
+
         // AND the count of topics for that section is now zero
         $this->assertEquals(Topic::where('section_id', $section->id)->count(), 0);
-        
+
         // BUT that section has soft deleted topics with match the orignal count
         $this->assertEquals(Topic::withTrashed()->where('section_id', $section->id)->count(), $topicsInSectionCount);
     }
 
+    /**
+     * @test
+     */
     public function deletingSectionSoftDeletesItsSubsections()
     {
         // given we have a user with a section and that sub section
          $user = factory(User::class)->create();
-        
+
         // AND we have a section
         $section = factory(Section::class)
             ->create([
@@ -117,5 +123,211 @@ class SectionTest extends TestCase
 
         // we have the right amount of soft deleted subsections
         $this->assertEquals(Section::withTrashed()->where('parent_id', $section->id)->count(), $subsectionCount);
+    }
+
+    /**
+     * @test
+     */
+    public function latestPostIsNullWhenTheSectionHasNoTopics()
+    {
+        /*
+        GIVEN a section with no topics
+        */
+
+        $moderator = factory(User::class)->create();
+        $section = factory(Section::class)->create([
+                'parent_id' => null,
+                'user_id' => $moderator->id
+        ]);
+
+        /*
+        WHEN
+        */
+
+        /*
+        THEN the latest post for that section is null
+        */
+
+        $this->assertNull($section->most_recent_post);
+    }
+
+    /**
+     * @test
+     */
+    public function latestPostIsNullWhenTheTopicsHaveNoPosts()
+    {
+        /*
+        GIVEN a section with no topics
+        */
+
+        $moderator = factory(User::class)->create();
+        $section = factory(Section::class)->create([
+                'parent_id' => null,
+                'user_id' => $moderator->id
+        ]);
+
+        /*
+        WHEN we add topics but no posts
+        */
+
+        factory(Topic::class, 10)->create([
+            'section_id' => $section->id
+        ]);
+
+        /*
+        THEN the latest post for that section is null
+        */
+
+        $this->assertNull($section->most_recent_post);
+    }
+
+    /**
+     * @test
+     */
+    public function latestPostReturnsMostRecentPostAsNewPostsAreAdded()
+    {
+        /*
+        GIVEN a section with topics
+        */
+
+        $moderator = factory(User::class)->create();
+        $section = factory(Section::class)->create([
+                'parent_id' => null,
+                'user_id' => $moderator->id
+        ]);
+
+        $topic1 = factory(Topic::class)->create([
+            'section_id' => $section->id
+        ]);
+
+        $topic2 = factory(Topic::class)->create([
+            'section_id' => $section->id
+        ]);
+
+        /*
+        WHEN a post is added to one of the topics
+        */
+
+        $post1 = factory(Post::class)->create([
+            'topic_id' => $topic1->id
+        ]);
+
+        /*
+        THEN the latest post for that section is that post
+        */
+        $this->assertEquals($post1->id, $section->most_recent_post->id);
+
+        /*
+        WHEN a second post is added to a topic in that section
+        */
+        $post2 = factory(Post::class)->create([
+            'topic_id' => $topic2->id
+        ]);
+
+        /*
+        THEN the latest post for that section becomes that second post
+        */
+        $this->assertEquals($post2->id, $section->most_recent_post->id);
+    }
+
+    /**
+     * @test
+     */
+    public function latestPostReturnsMostRecentPostAsPostsAreRemoved()
+    {
+
+        /*
+        GIVEN a section with topics, and a first and second post
+        */
+
+        $moderator = factory(User::class)->create();
+        $section = factory(Section::class)->create([
+                'parent_id' => null,
+                'user_id' => $moderator->id
+        ]);
+        $topic1 = factory(Topic::class)->create([
+            'section_id' => $section->id
+        ]);
+        $topic2 = factory(Topic::class)->create([
+            'section_id' => $section->id
+        ]);
+
+        $post1 = factory(Post::class)->create([
+            'topic_id' => $topic1->id
+        ]);
+        $post2 = factory(Post::class)->create([
+            'topic_id' => $topic2->id
+        ]);
+        
+        // second is the latest
+        $this->assertEquals($post2->id, $section->most_recent_post->id);
+
+        /*
+        WHEN the second post is removed
+        */
+        $post2->delete();
+
+        /*
+        THEN the latest post for that section becomes the first post
+        */
+        $this->assertEquals($post1->id, $section->most_recent_post->id);
+
+        /*
+        WHEN the first post is removed
+        */
+        $post1->delete();
+
+        /*
+        THEN the latest post for that section becomes null
+        */
+        $this->assertEquals(null, $section->most_recent_post);
+    }
+
+     /**
+     * @test
+     */
+    public function latestPostReturnsNullWhenTopicWithPreviousLatestPostIsMovedToAnotherSection()
+    {
+        /*
+        GIVEN a section with a topic with a post which is the latest post for that section
+        */
+
+        $moderator = factory(User::class)->create();
+        $section = factory(Section::class)->create([
+                'parent_id' => null,
+                'user_id' => $moderator->id
+        ]);
+        
+        $topic1 = factory(Topic::class)->create([
+            'section_id' => $section->id
+        ]);
+        
+        $post1 = factory(Post::class)->create([
+            'topic_id' => $topic1->id
+        ]);
+        
+        // post1 is the latest post
+        $this->assertEquals($post1->id, $section->most_recent_post->id);
+
+        /*
+        WHEN the topic is moved to another section
+        */
+
+        $section2 = factory(Section::class)->create([
+                'parent_id' => null,
+                'user_id' => $moderator->id
+        ]);
+        $topic1->section_id = $section2->id;
+        $topic1->save();
+
+        /*
+        THEN the latest post for that section becomes null
+        */
+        $this->assertNull($section->most_recent_post);
+
+        /*
+        AND the latest post for the new section is the original post
+        */
+        $this->assertEquals($post1->id, $section2->most_recent_post->id);
     }
 }


### PR DESCRIPTION
this PR saves memory and repeated database requests by caching the section->latest_post attribute and then invalidating that cache when the result might change.