### PR TITLE
fix for syntax error for php 7.2

### DIFF
--- a/app/Http/Controllers/Nexus/SectionController.php
+++ b/app/Http/Controllers/Nexus/SectionController.php
@@ -68,7 +68,7 @@ class SectionController extends Controller
             'moderator:id,username',
             'sections.moderator:id,username',
             'sections.sections',
-            'topics.most_recent_post.author:id,username',
+            'topics.most_recent_post.author:id,username'
         );
         
         ActivityHelper::updateActivity(


### PR DESCRIPTION
turns out trailing commas are too new for 7.2; was introducted in 7.3