### PR TITLE
use bootstrap for pagination rather than the new tailwind default

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -3,6 +3,7 @@
 namespace App\Providers;
 
 use App\Mode;
+use Illuminate\Pagination\Paginator;
 use Illuminate\Support\Facades\View;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\ServiceProvider;
@@ -29,6 +30,9 @@ class AppServiceProvider extends ServiceProvider
         }
         
         View::share('mode', $mode);
+
+        // use bootstrap for pagination
+        Paginator::useBootstrap();
     }
 
     /**


### PR DESCRIPTION
missed setting from last laravel upgrade broke the display of pagination links; this reverts it back to using the bootstrap markup