### PR TITLE
allow formatting in topic and heading title

### DIFF
--- a/resources/views/components/heading.blade.php
+++ b/resources/views/components/heading.blade.php
@@ -1,5 +1,5 @@
 <h1 class="display-4">
-    {{ $heading }}
+    {!! Str::inlineMarkdown($heading) !!}
     @isset($icon)
     <span style="opacity: 0.2">{{ $icon }}</span>
     @endisset

--- a/resources/views/components/topic-heading.blade.php
+++ b/resources/views/components/topic-heading.blade.php
@@ -16,6 +16,6 @@
             @default
                 <x-heroicon-s-chat-bubble-bottom-center-text class="icon_large {{ $textClass }}" />
         @endswitch
-        {{ $title }}
+        {!! Str::inlineMarkdown($title) !!}
     </h2>
 </a>


### PR DESCRIPTION
this fixes the issue where special characters would appear unencoded in section and topic titles

this is for issue https://github.com/christiancable/nexus5ive/issues/537