### PR TITLE
add database indexes for query performance

### DIFF
--- a/database/migrations/2026_05_16_102731_add_critical_indexes.php
+++ b/database/migrations/2026_05_16_102731_add_critical_indexes.php
@@ -1,0 +1,48 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        // Covers latestPostByTime (ofMany max time) and getMostRecentPostTimeAttribute:
+        // WHERE topic_id = ? ORDER BY time DESC
+        Schema::table('posts', function (Blueprint $table) {
+            $table->index(['topic_id', 'time'], 'posts_topic_id_time_index');
+        });
+
+        // Covers recentTopics raw SQL (GROUP BY topic_id / MAX(id) DESC)
+        // and routeToPost pagination count (WHERE topic_id = ? AND id >= ?)
+        Schema::table('posts', function (Blueprint $table) {
+            $table->index(['topic_id', 'id'], 'posts_topic_id_id_index');
+        });
+
+        // Covers the most frequent ViewHelper query pattern appearing 4+ times:
+        // WHERE topic_id = ? AND user_id = ?
+        // The unique constraint also enforces one view record per user-topic pair.
+        Schema::table('views', function (Blueprint $table) {
+            $table->unique(['user_id', 'topic_id'], 'views_user_id_topic_id_unique');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('views', function (Blueprint $table) {
+            $table->dropUnique('views_user_id_topic_id_unique');
+        });
+
+        Schema::table('posts', function (Blueprint $table) {
+            $table->dropIndex('posts_topic_id_id_index');
+            $table->dropIndex('posts_topic_id_time_index');
+        });
+    }
+};

--- a/database/migrations/2026_05_16_102732_add_supporting_indexes.php
+++ b/database/migrations/2026_05_16_102732_add_supporting_indexes.php
@@ -1,0 +1,94 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        // Missing FK index on posts.update_user_id (editor relation)
+        Schema::table('posts', function (Blueprint $table) {
+            $table->index('update_user_id', 'posts_update_user_id_index');
+        });
+
+        // Covers User::views relation and leap sort: WHERE user_id = ? ORDER BY latest_view_date DESC
+        Schema::table('views', function (Blueprint $table) {
+            $table->index(['user_id', 'latest_view_date'], 'views_user_id_latest_view_date_index');
+        });
+
+        // Covers topics ordered by weight within a section (moderator-controlled sections)
+        // and sticky + created_at ordering for user-topic sections
+        Schema::table('topics', function (Blueprint $table) {
+            $table->index(['section_id', 'weight'], 'topics_section_id_weight_index');
+            $table->index(['section_id', 'sticky', 'created_at'], 'topics_section_id_sticky_created_at_index');
+        });
+
+        // Covers ReportController::index: status-filtered list ordered by created_at DESC
+        // and missing FK indexes on reporter/moderator
+        Schema::table('reports', function (Blueprint $table) {
+            $table->index(['status', 'created_at'], 'reports_status_created_at_index');
+            $table->index('reporter_id', 'reports_reporter_id_index');
+            $table->index('moderator_id', 'reports_moderator_id_index');
+        });
+
+        // Covers User::chats (WHERE owner_id ORDER BY updated_at DESC)
+        // and User::unreadChats (WHERE owner_id AND is_read = false ORDER BY updated_at DESC)
+        Schema::table('chats', function (Blueprint $table) {
+            $table->index(['owner_id', 'updated_at'], 'chats_owner_id_updated_at_index');
+            $table->index(['owner_id', 'is_read', 'updated_at'], 'chats_owner_id_is_read_updated_at_index');
+        });
+
+        // Covers User::newCommentCount: WHERE user_id = ? AND read = false
+        Schema::table('comments', function (Blueprint $table) {
+            $table->index(['user_id', 'read'], 'comments_user_id_read_index');
+        });
+
+        // Covers ActivityHelper::recentActivities: WHERE time >= ?
+        Schema::table('activities', function (Blueprint $table) {
+            $table->index('time', 'activities_time_index');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('activities', function (Blueprint $table) {
+            $table->dropIndex('activities_time_index');
+        });
+
+        Schema::table('comments', function (Blueprint $table) {
+            $table->dropIndex('comments_user_id_read_index');
+        });
+
+        Schema::table('chats', function (Blueprint $table) {
+            $table->dropIndex('chats_owner_id_is_read_updated_at_index');
+            $table->dropIndex('chats_owner_id_updated_at_index');
+        });
+
+        Schema::table('reports', function (Blueprint $table) {
+            $table->dropIndex('reports_moderator_id_index');
+            $table->dropIndex('reports_reporter_id_index');
+            $table->dropIndex('reports_status_created_at_index');
+        });
+
+        Schema::table('topics', function (Blueprint $table) {
+            $table->dropIndex('topics_section_id_sticky_created_at_index');
+            $table->dropIndex('topics_section_id_weight_index');
+        });
+
+        Schema::table('views', function (Blueprint $table) {
+            $table->dropIndex('views_user_id_latest_view_date_index');
+        });
+
+        Schema::table('posts', function (Blueprint $table) {
+            $table->dropIndex('posts_update_user_id_index');
+        });
+    }
+};


### PR DESCRIPTION
Two migrations, deployable and rollable-back independently:

Critical (add_critical_indexes):
- posts (topic_id, time) — covers latestPostByTime ofMany and getMostRecentPostTimeAttribute ORDER BY time DESC queries
- posts (topic_id, id) — covers recentTopics GROUP BY/MAX(id) raw SQL and routeToPost pagination count WHERE id >= ?
- views (user_id, topic_id) UNIQUE — covers the most frequent ViewHelper pattern (4+ calls per request); unique constraint also enforces one view record per user-topic pair

Supporting (add_supporting_indexes):
- posts (update_user_id) — missing FK index on editor relation
- views (user_id, latest_view_date) — covers leap sort and User::views ordering
- topics (section_id, weight) — moderator-ordered section listing
- topics (section_id, sticky, created_at) — user-topic section ordering
- reports (status, created_at) — admin report list filtered + ordered
- reports (reporter_id), (moderator_id) — missing FK indexes
- chats (owner_id, updated_at) — User::chats relation with DESC sort
- chats (owner_id, is_read, updated_at) — User::unreadChats filtering + sort
- comments (user_id, read) — User::newCommentCount unread count query
- activities (time) — ActivityHelper::recentActivities time filter