### PR TITLE
Fix supporting indexes migration failing on production MySQL

### DIFF
--- a/database/migrations/2026_05_16_102732_add_supporting_indexes.php
+++ b/database/migrations/2026_05_16_102732_add_supporting_indexes.php
@@ -49,6 +49,11 @@ return new class extends Migration
         });
 
         // Covers ActivityHelper::recentActivities: WHERE time >= ?
+        // Also fixes the zero-date default that causes MySQL strict mode to reject any ALTER TABLE on this table.
+        Schema::table('activities', function (Blueprint $table) {
+            $table->timestamp('time')->useCurrent()->change();
+        });
+
         Schema::table('activities', function (Blueprint $table) {
             $table->index('time', 'activities_time_index');
         });

--- a/database/migrations/2026_05_16_102732_add_supporting_indexes.php
+++ b/database/migrations/2026_05_16_102732_add_supporting_indexes.php
@@ -11,42 +11,65 @@ return new class extends Migration
      */
     public function up(): void
     {
+        // Guards on each block make this safe to re-run if a prior deploy partially applied indexes.
+        // MySQL DDL is not transactional, so a mid-migration failure leaves some indexes behind.
+
         // Missing FK index on posts.update_user_id (editor relation)
-        Schema::table('posts', function (Blueprint $table) {
-            $table->index('update_user_id', 'posts_update_user_id_index');
-        });
+        if (! Schema::hasIndex('posts', 'posts_update_user_id_index')) {
+            Schema::table('posts', function (Blueprint $table) {
+                $table->index('update_user_id', 'posts_update_user_id_index');
+            });
+        }
 
         // Covers User::views relation and leap sort: WHERE user_id = ? ORDER BY latest_view_date DESC
-        Schema::table('views', function (Blueprint $table) {
-            $table->index(['user_id', 'latest_view_date'], 'views_user_id_latest_view_date_index');
-        });
+        if (! Schema::hasIndex('views', 'views_user_id_latest_view_date_index')) {
+            Schema::table('views', function (Blueprint $table) {
+                $table->index(['user_id', 'latest_view_date'], 'views_user_id_latest_view_date_index');
+            });
+        }
 
         // Covers topics ordered by weight within a section (moderator-controlled sections)
         // and sticky + created_at ordering for user-topic sections
         Schema::table('topics', function (Blueprint $table) {
-            $table->index(['section_id', 'weight'], 'topics_section_id_weight_index');
-            $table->index(['section_id', 'sticky', 'created_at'], 'topics_section_id_sticky_created_at_index');
+            if (! Schema::hasIndex('topics', 'topics_section_id_weight_index')) {
+                $table->index(['section_id', 'weight'], 'topics_section_id_weight_index');
+            }
+            if (! Schema::hasIndex('topics', 'topics_section_id_sticky_created_at_index')) {
+                $table->index(['section_id', 'sticky', 'created_at'], 'topics_section_id_sticky_created_at_index');
+            }
         });
 
         // Covers ReportController::index: status-filtered list ordered by created_at DESC
         // and missing FK indexes on reporter/moderator
         Schema::table('reports', function (Blueprint $table) {
-            $table->index(['status', 'created_at'], 'reports_status_created_at_index');
-            $table->index('reporter_id', 'reports_reporter_id_index');
-            $table->index('moderator_id', 'reports_moderator_id_index');
+            if (! Schema::hasIndex('reports', 'reports_status_created_at_index')) {
+                $table->index(['status', 'created_at'], 'reports_status_created_at_index');
+            }
+            if (! Schema::hasIndex('reports', 'reports_reporter_id_index')) {
+                $table->index('reporter_id', 'reports_reporter_id_index');
+            }
+            if (! Schema::hasIndex('reports', 'reports_moderator_id_index')) {
+                $table->index('moderator_id', 'reports_moderator_id_index');
+            }
         });
 
         // Covers User::chats (WHERE owner_id ORDER BY updated_at DESC)
         // and User::unreadChats (WHERE owner_id AND is_read = false ORDER BY updated_at DESC)
         Schema::table('chats', function (Blueprint $table) {
-            $table->index(['owner_id', 'updated_at'], 'chats_owner_id_updated_at_index');
-            $table->index(['owner_id', 'is_read', 'updated_at'], 'chats_owner_id_is_read_updated_at_index');
+            if (! Schema::hasIndex('chats', 'chats_owner_id_updated_at_index')) {
+                $table->index(['owner_id', 'updated_at'], 'chats_owner_id_updated_at_index');
+            }
+            if (! Schema::hasIndex('chats', 'chats_owner_id_is_read_updated_at_index')) {
+                $table->index(['owner_id', 'is_read', 'updated_at'], 'chats_owner_id_is_read_updated_at_index');
+            }
         });
 
         // Covers User::newCommentCount: WHERE user_id = ? AND read = false
-        Schema::table('comments', function (Blueprint $table) {
-            $table->index(['user_id', 'read'], 'comments_user_id_read_index');
-        });
+        if (! Schema::hasIndex('comments', 'comments_user_id_read_index')) {
+            Schema::table('comments', function (Blueprint $table) {
+                $table->index(['user_id', 'read'], 'comments_user_id_read_index');
+            });
+        }
 
         // Covers ActivityHelper::recentActivities: WHERE time >= ?
         // Also fixes the zero-date default that causes MySQL strict mode to reject any ALTER TABLE on this table.
@@ -54,9 +77,11 @@ return new class extends Migration
             $table->timestamp('time')->useCurrent()->change();
         });
 
-        Schema::table('activities', function (Blueprint $table) {
-            $table->index('time', 'activities_time_index');
-        });
+        if (! Schema::hasIndex('activities', 'activities_time_index')) {
+            Schema::table('activities', function (Blueprint $table) {
+                $table->index('time', 'activities_time_index');
+            });
+        }
     }
 
     /**


### PR DESCRIPTION
## Problem

Deploying `2026_05_16_102732_add_supporting_indexes` failed on production MySQL in two different ways across two deploy attempts.

**First attempt — error 1067 (strict mode reject on `activities`)**

MySQL strict mode (`NO_ZERO_DATE`) validates all column defaults whenever any `ALTER TABLE` runs on a table. The `activities.time` column was created in 2016 with a bare `timestamp('time')`, leaving it with a `0000-00-00 00:00:00` default. This caused MySQL to reject even a simple `ADD INDEX` on that table with:

```
SQLSTATE[42000]: 1067 Invalid default value for 'time'
SQL: alter table `activities` add index `activities_time_index`(`time`)
```

Note: the existing `2026_01_01_000000_fix_timestamp_defaults` migration fixed this for `sections`, `topics`, `posts`, `users`, `comments`, and `views` — but `activities` was missed.

**Second attempt — error 1061 (duplicate key after partial apply)**

MySQL DDL is not transactional. The first failed run had already applied all the index creations that came *before* the `activities` block. After rolling back the migration record and re-running, the migration immediately hit duplicate key errors on indexes that already existed on disk.

## Fix

Two commits:

1. **Fix strict mode error** — add `->timestamp('time')->useCurrent()->change()` before adding the `activities_time_index`, to normalise the column default to `CURRENT_TIMESTAMP`.

2. **Make migration idempotent** — guard every index creation with `Schema::hasIndex()` so the migration is safe to re-run regardless of how far a previous attempt got.

## Test plan

- [x] All 372 tests pass locally
- [ ] Deploy to production and confirm both migrations run cleanly from a pending state