### PR TITLE
Fix activities ALTER TABLE failing on created_at zero-date default

### DIFF
--- a/database/migrations/2026_05_16_102732_add_supporting_indexes.php
+++ b/database/migrations/2026_05_16_102732_add_supporting_indexes.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration
@@ -72,10 +73,15 @@ return new class extends Migration
         }
 
         // Covers ActivityHelper::recentActivities: WHERE time >= ?
-        // Also fixes the zero-date default that causes MySQL strict mode to reject any ALTER TABLE on this table.
-        Schema::table('activities', function (Blueprint $table) {
-            $table->timestamp('time')->useCurrent()->change();
-        });
+        // Also fixes zero-date defaults on all three timestamp columns in activities — MySQL validates
+        // every column default on any ALTER TABLE, so all must be fixed in one statement.
+        // (fix_timestamp_defaults missed this table; same pattern used there for all other tables.)
+        if (DB::getDriverName() === 'mysql') {
+            DB::statement('ALTER TABLE `activities`
+                MODIFY `time` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                MODIFY `created_at` TIMESTAMP NULL DEFAULT NULL,
+                MODIFY `updated_at` TIMESTAMP NULL DEFAULT NULL');
+        }
 
         if (! Schema::hasIndex('activities', 'activities_time_index')) {
             Schema::table('activities', function (Blueprint $table) {


### PR DESCRIPTION
## Problem

The previous fix (#640) changed `activities.time` using Blueprint's `->change()`, which generates `ALTER TABLE activities MODIFY time ...`. MySQL validates **every** column's default in the table when any `ALTER TABLE` runs — and `activities.created_at` and `updated_at` also have zero-date defaults, causing error 1067:

```
SQLSTATE[42000]: 1067 Invalid default value for 'created_at'
SQL: alter table `activities` modify `time` timestamp not null default CURRENT_TIMESTAMP
```

The `fix_timestamp_defaults` migration (batch 15) fixed this for `sections`, `topics`, `posts`, `users`, `comments`, and `views` — but the `activities` table was missed entirely.

## Fix

Replace Blueprint `->change()` with a raw `DB::statement` that normalises all three timestamp columns (`time`, `created_at`, `updated_at`) in a single `ALTER TABLE`, exactly matching the pattern used in `fix_timestamp_defaults` for every other table. MySQL-only, guarded with `DB::getDriverName() === 'mysql'`.

## Test plan

- [x] All 372 tests pass locally
- [ ] Deploy to production and confirm migration runs cleanly from pending state