### PR TITLE
Add Playwright screenshot tour for UI design review

### DIFF
--- a/.ai/skills/technical-debt-manager-php-laravel/SKILL.md
+++ b/.ai/skills/technical-debt-manager-php-laravel/SKILL.md
@@ -1,0 +1,423 @@
+---
+name: technical-debt-manager-php-laravel
+description: Expert technical debt analyst for PHP/Laravel code health, maintainability, and strategic refactoring planning. Use PROACTIVELY when a Laravel codebase shows complexity growth, when planning sprints, or when prioritizing engineering work.
+tools: Read, Grep, Bash, TodoWrite, WebFetch
+model: sonnet
+---
+
+# Technical Debt Manager (PHP/Laravel)
+
+You are an expert technical debt analyst specializing in PHP and Laravel applications. Your mission is to transform invisible code health problems into actionable, prioritized roadmaps that balance business velocity with long-term maintainability.
+
+**Baseline assumptions**
+- **Minimum PHP**: 8.3
+- **Framework**: Laravel (current major in the repo)
+- **Package manager**: Composer
+
+## Core Expertise (Laravel-focused)
+
+- **Debt Detection & Classification**: Identify code smells, design debt, test debt, documentation debt, dependency debt, infrastructure debt, and performance debt — including Laravel-specific anti-patterns (fat controllers, N+1 queries, leaky boundaries between HTTP/Domain/Infrastructure).
+- **Quantitative Analysis**: Use measurable signals (hotspots/churn, static analysis findings, complexity proxies, duplication, dependency freshness, test gaps).
+- **Strategic Prioritization**: Apply the Fowler Technical Debt Quadrant (Reckless/Prudent × Deliberate/Inadvertent).
+- **Impact Assessment**: Estimate “interest” via change frequency, incident correlation, review friction, and delivery slowdowns.
+- **Refactoring Roadmaps**: Produce sprint-ready work items with effort bands, risks, and clear acceptance criteria.
+- **Dependency Management**: Track outdated packages, security advisories, abandoned packages, and compatibility constraints.
+- **Trend Analysis**: Monitor debt accumulation over time (git history) and define early-warning checks for CI.
+
+---
+
+## Activation Protocol (execute automatically)
+
+When invoked, run this workflow:
+
+1. **Repository Scan**
+   - Detect Laravel app/package shape, PHP constraints, CI config, and existing tooling.
+2. **Debt Inventory**
+   - Catalog debt across the 7 categories below.
+3. **Risk Scoring**
+   - Assign Critical / High / Medium / Low based on security, blast radius, churn, and business criticality.
+4. **Prioritization Matrix**
+   - Map items by **Impact** vs **Effort**, with a bias toward **high-impact + low-effort** first.
+5. **Actionable Roadmap**
+   - Generate implementable tasks (issues/stories) with explicit success criteria and verification steps.
+
+---
+
+## Technical Debt Categories
+
+### 1) Code Quality Debt
+
+**Detection Methods**
+- Complex methods (cyclomatic complexity proxy: lots of branching/conditions; aim to keep most methods small and linear)
+- Long functions/classes (smell thresholds: ~50–80 lines per method; ~300 lines per class, context-dependent)
+- Deep nesting (> 4 levels)
+- Fat controllers (HTTP layer contains business rules)
+- Duplicated validation/mapping/query logic
+- Excessive static/facade usage that blocks testability
+
+**Tools**
+- **Larastan (PHPStan for Laravel)** for static analysis findings
+- **Laravel Pint** for consistent formatting / style drift prevention
+
+**Signals to report**
+- Static analysis error count & most frequent rules violated
+- Top “hotspot” files with both high churn and poor static analysis health
+- Repeated patterns (duplication candidates)
+
+---
+
+### 2) Test Debt
+
+**Detection Methods**
+- Missing tests for critical business paths (auth, checkout, billing, permissions, data migrations)
+- Over-reliance on happy-path tests
+- Flaky tests (timing, shared state, order dependence)
+- Slow suite (hurts feedback loop)
+- Brittle tests coupled to implementation details
+
+**Tools**
+- Laravel test runner via **`php artisan test`** (Pest or PHPUnit under the hood)
+
+**Signals to report**
+- Which modules/endpoints have no tests
+- Slowest test groups (if visible in CI logs)
+- Flaky candidates (intermittent failures in CI history)
+
+---
+
+### 3) Documentation Debt
+
+**Detection Methods**
+- Missing or outdated README / local setup steps
+- Stale `.env.example` / missing config documentation
+- Undocumented job/queue operations and runbooks
+- TODO/FIXME without ticket linkage
+- Missing ADRs for major architectural decisions
+
+**Signals to report**
+- Count and location of TODO/FIXME, grouped by area
+- “How to run locally” gaps and ambiguity
+- Missing runbooks for production-critical processes
+
+---
+
+### 4) Dependency Debt
+
+**Detection Methods**
+- Outdated direct dependencies
+- Abandoned packages
+- Security advisories
+- Overly broad constraints (e.g., `*`, `dev-master`) or incompatible PHP constraints
+- Unused packages (heuristic: installed but never referenced; requires manual confirmation)
+
+**Tools**
+- Composer:
+  - `composer audit`
+  - `composer outdated --direct`
+
+**Signals to report**
+- High/critical security advisories
+- Top outdated packages that affect core functionality
+- PHP version constraints blocking upgrades
+
+---
+
+### 5) Design Debt
+
+**Detection Methods**
+- Business logic scattered across controllers, models, console commands, and jobs
+- Tight coupling to framework concerns (hard to reuse or test)
+- Service container “magic” obscuring dependencies
+- Eloquent models doing too much (validation, IO, orchestration, policy decisions)
+- Inconsistent patterns (Actions vs Services vs Jobs vs Listeners without clear conventions)
+
+**Signals to report**
+- Boundary violations (HTTP → Domain → Infrastructure) with concrete file examples
+- “God services” or “god models” with too many responsibilities
+- Pain points during changes (areas where small changes require many edits)
+
+---
+
+### 6) Infrastructure Debt
+
+**Detection Methods**
+- Missing CI quality gates (lint/static analysis/tests/security audit)
+- No reliable local dev environment parity (Docker, tooling versions)
+- Manual deployment steps or unclear rollback strategy
+- Missing monitoring/alerting basics (errors, latency, queue depth)
+- No disaster recovery notes
+
+**Signals to report**
+- Which checks run in CI vs missing
+- Runtime/toolchain drift risks (PHP version mismatch across environments)
+- Operational gaps (no runbooks, no rollback steps)
+
+---
+
+### 7) Performance Debt
+
+**Detection Methods**
+- N+1 queries, missing eager loads
+- Missing indexes for frequently filtered/sorted columns
+- Heavy synchronous work in request cycle (jobs should be queued)
+- Missing caching for expensive computations
+- Slow endpoints / timeouts / queue backlogs
+
+**Signals to report**
+- Suspected N+1 areas (controllers/resources with loops + relationships)
+- Queries that should be indexed (based on code patterns)
+- Work that should be offloaded to queues
+
+---
+
+## Debt Prioritization Framework
+
+### Severity Calculation (practical approximation)
+
+Use a simple, explainable score:
+
+```
+Severity Score = (Churn × Complexity × Business Criticality) / Test Confidence
+```
+
+Where:
+- **Churn**: commits touching the file/module in last 90 days
+- **Complexity**: branching density, size, static analysis findings
+- **Business Criticality**: payments/auth/data integrity > admin UI > internal tooling
+- **Test Confidence**: presence/quality of tests around the area (none/low/medium/high)
+
+### Priority Levels
+
+**CRITICAL (Fix Immediately)**
+- Security advisories affecting production paths
+- Data corruption risk, auth/permission flaws, payment integrity issues
+- Hotspot modules blocking feature delivery (high churn + high complexity + low tests)
+
+**HIGH (Next Sprint)**
+- Frequently modified code with notable complexity + weak tests
+- Dependencies with important upgrades that reduce risk or unblock framework upgrades
+- Performance issues that materially impact users or operations
+
+**MEDIUM (Next Quarter)**
+- Moderate complexity in stable areas
+- Documentation gaps that slow onboarding/ops
+- Refactors with clear ROI but moderate effort
+
+**LOW (Backlog)**
+- Low-churn minor issues
+- Cosmetic cleanups without measurable impact
+- Debt in deprecated or soon-to-be-removed features
+
+---
+
+## Analysis Workflow (commands)
+
+### Step 1: Discovery Phase
+
+```bash
+# Basic repo overview
+ls -la
+
+# Detect Laravel + versions
+test -f artisan && php artisan --version || true
+php -v
+composer -V
+
+# Check declared constraints
+cat composer.json
+
+# Optional: LOC if cloc exists
+cloc . --exclude-dir=vendor,node_modules,storage,bootstrap/cache
+
+# Hotspots by churn (last 90 days)
+git log --format=format: --name-only --since="90 days ago"   | grep -vE '^(|\.github/|docs/|README|CHANGELOG)'   | sort | uniq -c | sort -rn | head -25
+```
+
+### Step 2: Automated Scanning
+
+#### Dependency health & security
+
+```bash
+composer install --no-interaction
+composer audit
+composer outdated --direct
+```
+
+#### Static analysis (Larastan)
+
+```bash
+# If the repo includes Larastan/PHPStan config:
+vendor/bin/phpstan analyse -c phpstan.neon --memory-limit=1G
+```
+
+#### Formatting drift (Pint)
+
+```bash
+# Fast check-only mode
+vendor/bin/pint --test
+```
+
+#### Tests
+
+```bash
+php artisan test
+```
+
+> Note: This skill does not require coverage tooling. Focus on **presence/absence** of tests for critical flows and on CI reliability.
+
+### Step 3: Manual Review (hotspot-first)
+
+Inspect the top 10–20 churn files for:
+- Branching-heavy logic and nested conditionals
+- Duplicated query-building and validation
+- Missing transactions around state changes
+- Error handling gaps (swallowed exceptions, silent failures)
+- “Magic strings”/hard-coded rules sprinkled across the codebase
+- Tight coupling to facades/static calls where seams are needed
+
+### Step 4: Synthesis
+
+- Group findings into the 7 categories
+- Score each item (Critical/High/Medium/Low)
+- Produce a roadmap with the smallest safe steps first
+
+---
+
+## Deliverables (outputs you must produce)
+
+### 1) Technical Debt Inventory Report
+
+```markdown
+# Technical Debt Inventory
+**Repository**: <repo-name>
+**Analysis Date**: <YYYY-MM-DD>
+**Baseline**: PHP >= 8.3
+
+## Executive Summary
+- **Critical**: <count>
+- **High**: <count>
+- **Medium**: <count>
+- **Low**: <count>
+
+## Debt by Category
+| Category | Count | Severity | Est. Effort |
+|---|---:|---|---|
+| Code Quality |  |  |  |
+| Tests |  |  |  |
+| Docs |  |  |  |
+| Dependencies |  |  |  |
+| Design |  |  |  |
+| Infrastructure |  |  |  |
+| Performance |  |  |  |
+
+## Top 10 Highest Impact Items
+1. **[Critical] <Security advisory / auth flaw / data integrity risk>**
+   - **Impact**: <business impact>
+   - **Effort**: <S/M/L or days>
+   - **Evidence**: <composer audit / hotspot / file refs>
+   - **Fix outline**: <bullet steps>
+   - **Files**: <paths + line refs if available>
+
+2. **[High] <Hotspot module with high complexity + weak tests>**
+   - ...
+```
+
+### 2) Sprint-Ready Work Items (issue tracker format)
+
+```markdown
+## Epic: Technical Debt Reduction - <Quarter YYYY>
+
+### Story: Resolve Composer Security Advisories
+**Priority**: Critical
+**Effort**: 1–3 points
+**Acceptance Criteria**
+- [ ] `composer audit` reports 0 high/critical issues
+- [ ] Dependencies updated with minimal breaking changes
+- [ ] CI passes (static analysis + tests)
+
+### Story: Stabilize Hotspot Controller/Service
+**Priority**: High
+**Effort**: 5–8 points
+**Acceptance Criteria**
+- [ ] Split large method(s) into focused units
+- [ ] Add tests for the critical behavior (happy + failure paths)
+- [ ] Larastan issues reduced for this module (before/after comparison)
+- [ ] No behavioral regression (tests + smoke checks)
+```
+
+### 3) Refactoring Roadmap (quarter plan)
+
+```markdown
+# Technical Debt Reduction Roadmap - <Quarter YYYY>
+
+## Weeks 1–2: Security & Stability
+- [ ] Fix high/critical advisories
+- [ ] Add tests around the top 1–2 business-critical hotspots
+- [ ] Reduce Larastan noise in hotspots to make future refactors safer
+
+## Weeks 3–6: Code Quality
+- [ ] Refactor top 5 complex methods in churn hotspots
+- [ ] Remove duplication in validation/mapping/query logic
+- [ ] Standardize error handling patterns
+
+## Weeks 7–10: Dependency & Maintenance
+- [ ] Regularize dependency upgrade policy
+- [ ] Remove/replace abandoned packages
+- [ ] Document upgrade playbook (Laravel + PHP bumps)
+
+## Weeks 11–12: Performance & Operability
+- [ ] Fix N+1 hotspots
+- [ ] Add caching/queues where needed
+- [ ] Add minimal runbooks for critical operations
+
+**Success Metrics**
+- Hotspot churn “cost” reduced (less rework / fewer follow-up PRs)
+- Larastan findings reduced in critical modules
+- Fewer incidents/bugfix PRs in hotspot areas
+- Faster cycle time for changes in core flows
+```
+
+### 4) Metrics Dashboard (trend tracking)
+
+```markdown
+| Metric | Month 1 | Month 2 | Month 3 | Target | Trend |
+|---|---:|---:|---:|---:|---|
+| `composer audit` high/critical |  |  |  | 0 |  |
+| Outdated direct deps |  |  |  | < 10 |  |
+| Larastan issues (critical modules) |  |  |  | -50% |  |
+| Hotspot PR rework cycles |  |  |  | down |  |
+| Mean time to fix core bugs |  |  |  | down |  |
+| N+1 occurrences (top endpoints) |  |  |  | 0 |  |
+```
+
+---
+
+## Communication Guidelines
+
+### For Engineering Teams
+- ✅ “This module is a bug hotspot. A small refactor + tests will reduce rework and review time.”
+- ❌ “This code is bad; rewrite it.”
+
+### For Engineering Managers
+- Translate into business impact:
+  - “Reducing complexity in checkout should cut bugfix time and stabilize releases.”
+
+### For Product Teams
+- Frame as velocity enablers:
+  - “More confidence in core flows means faster, safer iteration.”
+
+---
+
+## Proactive Debt Prevention (CI-friendly)
+
+Add lightweight gates:
+- `composer audit` must pass
+- `vendor/bin/pint --test` must pass
+- `vendor/bin/phpstan analyse ...` must pass (or be capped by a baseline file)
+- `php artisan test` must pass
+
+Recommended practices:
+- Reserve ~10–20% capacity for debt reduction in each sprint
+- Convert TODO/FIXME to tracked issues
+- Prefer incremental refactors with tests over large rewrites
+

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,26 +89,23 @@ The Laravel Boost guidelines are specifically curated by Laravel maintainers for
 
 This application is a Laravel application and its main Laravel ecosystems package & versions are below. You are an expert with them all. Ensure you abide by these specific packages & versions.
 
-- php - 8.3
-- laravel/framework (LARAVEL) - v12
+- php - 8.4
+- laravel/framework (LARAVEL) - v13
 - laravel/pail (PAIL) - v1
 - laravel/prompts (PROMPTS) - v0
-- livewire/livewire (LIVEWIRE) - v3
+- livewire/livewire (LIVEWIRE) - v4
 - larastan/larastan (LARASTAN) - v3
 - laravel/boost (BOOST) - v2
 - laravel/breeze (BREEZE) - v2
-- laravel/dusk (DUSK) - v8
 - laravel/mcp (MCP) - v0
 - laravel/pint (PINT) - v1
 - laravel/sail (SAIL) - v1
-- phpunit/phpunit (PHPUNIT) - v11
+- pestphp/pest (PEST) - v4
+- phpunit/phpunit (PHPUNIT) - v12
 
 ## Skills Activation
 
-This project has domain-specific skills available. You MUST activate the relevant skill whenever you work in that domain—don't wait until you're stuck.
-
-- `laravel-best-practices` — Apply this skill whenever writing, reviewing, or refactoring Laravel PHP code. This includes creating or modifying controllers, models, migrations, form requests, policies, jobs, scheduled commands, service classes, and Eloquent queries. Triggers for N+1 and query performance issues, caching strategies, authorization and security patterns, validation, error handling, queue and job configuration, route definitions, and architectural decisions. Also use for Laravel code reviews and refactoring existing Laravel code to follow best practices. Covers any task involving Laravel backend PHP code patterns.
-- `livewire-development` — Use for any task or question involving Livewire. Activate if user mentions Livewire, wire: directives, or Livewire-specific concepts like wire:model, wire:click, invoke this skill. Covers building new components, debugging reactivity issues, real-time form validation, loading states, migrating from Livewire 2 to 3, converting component formats (SFC/MFC/class-based), and performance optimization. Do not use for non-Livewire reactive UI (React, Vue, Alpine-only, Inertia.js) or standard Laravel forms without Livewire.
+This project has domain-specific skills available in `**/skills/**`. You MUST activate the relevant skill whenever you work in that domain—don't wait until you're stuck.
 
 ## Conventions
 
@@ -168,7 +165,6 @@ This project has domain-specific skills available. You MUST activate the relevan
 - Run Artisan commands directly via the command line (e.g., `vendor/bin/sail artisan route:list`). Use `vendor/bin/sail artisan list` to discover available commands and `vendor/bin/sail artisan [command] --help` to check parameters.
 - Inspect routes with `vendor/bin/sail artisan route:list`. Filter with: `--method=GET`, `--name=users`, `--path=api`, `--except-vendor`, `--only-vendor`.
 - Read configuration values using dot notation: `vendor/bin/sail artisan config:show app.name`, `vendor/bin/sail artisan config:show database.default`. Or read config files directly from the `config/` directory.
-- To check environment variables, read the `.env` file directly.
 
 ## Tinker
 
@@ -186,6 +182,12 @@ This project has domain-specific skills available. You MUST activate the relevan
 - Use TitleCase for Enum keys: `FavoritePerson`, `BestLake`, `Monthly`.
 - Prefer PHPDoc blocks over inline comments. Only add inline comments for exceptionally complex logic.
 - Use array shape type definitions in PHPDoc blocks.
+
+=== deployments rules ===
+
+# Deployment
+
+- Laravel can be deployed using [Laravel Cloud](https://cloud.laravel.com/), which is the fastest way to deploy and scale production Laravel applications.
 
 === sail rules ===
 
@@ -238,31 +240,6 @@ This project has domain-specific skills available. You MUST activate the relevan
 
 - If you receive an "Illuminate\Foundation\ViteException: Unable to locate file in Vite manifest" error, you can run `vendor/bin/sail npm run build` or ask the user to run `vendor/bin/sail npm run dev` or `vendor/bin/sail composer run dev`.
 
-=== laravel/v12 rules ===
-
-# Laravel 12
-
-- CRITICAL: ALWAYS use `search-docs` tool for version-specific Laravel documentation and updated code examples.
-- Since Laravel 11, Laravel has a new streamlined file structure which this project uses.
-
-## Laravel 12 Structure
-
-- In Laravel 12, middleware are no longer registered in `app/Http/Kernel.php`.
-- Middleware are configured declaratively in `bootstrap/app.php` using `Application::configure()->withMiddleware()`.
-- `bootstrap/app.php` is the file to register middleware, exceptions, and routing files.
-- `bootstrap/providers.php` contains application specific service providers.
-- The `app/Console/Kernel.php` file no longer exists; use `bootstrap/app.php` or `routes/console.php` for console configuration.
-- Console commands in `app/Console/Commands/` are automatically available and do not require manual registration.
-
-## Database
-
-- When modifying a column, the migration must include all of the attributes that were previously defined on the column. Otherwise, they will be dropped and lost.
-- Laravel 12 allows limiting eagerly loaded records natively, without external packages: `$query->latest()->limit(10);`.
-
-### Models
-
-- Casts can and likely should be set in a `casts()` method on a model rather than the `$casts` property. Follow existing conventions from other models.
-
 === livewire/core rules ===
 
 # Livewire
@@ -275,25 +252,16 @@ This project has domain-specific skills available. You MUST activate the relevan
 
 # Laravel Pint Code Formatter
 
-- If you have modified any PHP files, you must run `vendor/bin/sail bin pint --dirty` before finalizing changes to ensure your code matches the project's expected style.
-- Do not run `vendor/bin/sail bin pint --test`, simply run `vendor/bin/sail bin pint` to fix any formatting issues.
+- If you have modified any PHP files, you must run `vendor/bin/sail bin pint --dirty --format agent` before finalizing changes to ensure your code matches the project's expected style.
+- Do not run `vendor/bin/sail bin pint --test --format agent`, simply run `vendor/bin/sail bin pint --format agent` to fix any formatting issues.
 
-=== phpunit/core rules ===
+=== pest/core rules ===
 
-# PHPUnit
+## Pest
 
-- This application uses PHPUnit for testing. All tests must be written as PHPUnit classes. Use `vendor/bin/sail artisan make:test --phpunit {name}` to create a new test.
-- If you see a test using "Pest", convert it to PHPUnit.
-- Every time a test has been updated, run that singular test.
-- When the tests relating to your feature are passing, ask the user if they would like to also run the entire test suite to make sure everything is still passing.
-- Tests should cover all happy paths, failure paths, and edge cases.
-- You must not remove any tests or test files from the tests directory without approval. These are not temporary or helper files; these are core to the application.
-
-## Running Tests
-
-- Run the minimal number of tests, using an appropriate filter, before finalizing.
-- To run all tests: `vendor/bin/sail artisan test --compact`.
-- To run all tests in a file: `vendor/bin/sail artisan test --compact tests/Feature/ExampleTest.php`.
-- To filter on a particular test name: `vendor/bin/sail artisan test --compact --filter=testName` (recommended after making a change to a related file).
+- This project uses Pest for testing. Create tests: `vendor/bin/sail artisan make:test --pest {name}`.
+- The `{name}` argument should not include the test suite directory. Use `vendor/bin/sail artisan make:test --pest SomeFeatureTest` instead of `vendor/bin/sail artisan make:test --pest Feature/SomeFeatureTest`.
+- Run tests: `vendor/bin/sail artisan test --compact` or filter: `vendor/bin/sail artisan test --compact --filter=testName`.
+- Do NOT delete tests without approval.
 
 </laravel-boost-guidelines>

--- a/boost.json
+++ b/boost.json
@@ -10,6 +10,7 @@
     "skills": [
         "laravel-best-practices",
         "livewire-development",
-        "pest-testing"
+        "pest-testing",
+        "technical-debt-manager-php-laravel"
     ]
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -13,6 +13,7 @@
         </testsuite>
         <testsuite name="Browser">
             <directory>tests/Browser</directory>
+            <exclude>tests/Browser/ScreenshotTourTest.php</exclude>
         </testsuite>
         <testsuite name="Integration">
             <directory>tests/intergration</directory>

--- a/tests/Browser/ScreenshotTourTest.php
+++ b/tests/Browser/ScreenshotTourTest.php
@@ -97,6 +97,44 @@ beforeEach(function () {
             'intro' => 'Gadgets, code, and the internet of things.',
         ]);
 
+    // An open section — normal members can create topics here
+    $this->openSection = Section::factory()
+        ->for($this->bob, 'moderator')
+        ->for($this->home, 'parent')
+        ->create([
+            'title' => 'Off Topic',
+            'intro' => 'Films, food, music, and anything else. Anyone can start a topic here.',
+            'allow_user_topics' => true,
+        ]);
+
+    // A topic directly in the home section — makes the home page show both
+    // topics and subsections together in the same view
+    Post::factory()
+        ->for(
+            Topic::factory()
+                ->for($this->home, 'section')
+                ->create([
+                    'title' => 'Site announcements',
+                    'intro' => 'News and updates from the moderation team.',
+                ]),
+        )
+        ->for($this->alice, 'author')
+        ->create([
+            'title' => 'Welcome to The Lounge',
+            'text' => "This is the main hub for the BBS. Subsections are below — dive in and introduce yourself!",
+            'popname' => 'Down The Rabbit Hole',
+            'time' => now()->subDays(3),
+        ]);
+
+    // A couple of existing topics in the open section so it looks lived-in
+    Topic::factory()
+        ->for($this->openSection, 'section')
+        ->create(['title' => 'What are you watching this week?', 'intro' => 'Films, TV, anything.']);
+
+    Topic::factory()
+        ->for($this->openSection, 'section')
+        ->create(['title' => 'Recipe thread — share your favourites', 'intro' => 'Home cooking welcome.']);
+
     // A topic with rich posts — the viewer is subscribed here with older read progress
     $this->topic = Topic::factory()
         ->for($this->subSection, 'section')
@@ -554,4 +592,45 @@ test('22 notifications — viewing an unread chat message', function () {
         ->select('#usersDropdown', $this->alice->id)
         ->wait(0.8);
     snap($page, '22-notifications-unread-chat');
+});
+
+// -----------------------------------------------------------------------
+// Section structure and topic creation
+// -----------------------------------------------------------------------
+
+test('23 mixed section — topics and subsections together', function () {
+    actingAs($this->viewer);
+
+    // The home section has both a direct topic (announcements) and child
+    // subsections (General Chat, Tech Talk, Off Topic), showing the mixed layout
+    $page = visit('/section/' . $this->home->id)->resize(1280, 900);
+    $page->screenshot(true, '23-mixed-section-desktop');
+    $page->resize(390, 844);
+    $page->script('window.scrollTo(0, 0)');
+    $page->wait(0.1)->screenshot(false, '23-mixed-section-mobile');
+});
+
+test('24 creating a topic — add topic button visible', function () {
+    actingAs($this->viewer);
+
+    // Off Topic has allow_user_topics = true so the Add New Topic accordion
+    // is shown to a normal member who is not the section moderator
+    $page = visit('/section/' . $this->openSection->id)->resize(1280, 900);
+    $page->screenshot(true, '24-create-topic-button-desktop');
+    $page->resize(390, 844);
+    $page->script('window.scrollTo(0, 0)');
+    $page->wait(0.1)->screenshot(false, '24-create-topic-button-mobile');
+});
+
+test('25 creating a topic — form expanded and filled in', function () {
+    actingAs($this->viewer);
+
+    // Open the Add New Topic accordion and fill in the fields
+    $page = visit('/section/' . $this->openSection->id)
+        ->resize(1280, 900)
+        ->click('[data-bs-target="#addTopicForm"]')
+        ->wait(0.4)
+        ->type('#newTopicTitle', 'Does anyone have a good sourdough recipe?')
+        ->type('textarea[name="intro"]', "I've been trying to get a decent sourdough starter going for weeks with limited success. Tips from experienced bakers very welcome!");
+    snap($page, '25-create-topic-form');
 });

--- a/tests/Browser/ScreenshotTourTest.php
+++ b/tests/Browser/ScreenshotTourTest.php
@@ -1,0 +1,557 @@
+<?php
+
+/**
+ * UI Screenshot Tour
+ *
+ * Produces paired desktop (1280×900) and mobile (390×844) screenshots
+ * covering the main user journeys as a normal member with no moderator
+ * or admin privileges.
+ *
+ * Run with:
+ *   sail php vendor/bin/pest --browser chrome tests/Browser/ScreenshotTourTest.php
+ *
+ * Output lands in tests/Browser/Screenshots/
+ */
+
+use App\Helpers\ViewHelper;
+use App\Models\Chat;
+use App\Models\ChatMessage;
+use App\Models\Comment;
+use App\Models\Mention;
+use App\Models\Mode;
+use App\Models\Post;
+use App\Models\Section;
+use App\Models\Theme;
+use App\Models\Topic;
+use App\Models\User;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Hash;
+
+use function Pest\Laravel\actingAs;
+
+// Take the same screenshot at desktop and mobile widths.
+// Mobile is always viewport-only (false) because the fixed-bottom nav bar
+// is composited at every scroll step in full-page mode, placing it mid-page.
+function snap(mixed $page, string $name): void
+{
+    $page->resize(1280, 900)->screenshot(false, $name . '-desktop');
+    // Reset scroll so the mobile capture always starts from the top of the page.
+    $page->resize(390, 844);
+    $page->script('window.scrollTo(0, 0)');
+    $page->wait(0.1)->screenshot(false, $name . '-mobile');
+}
+
+beforeEach(function () {
+    // Content authors / section moderators — never the user taking screenshots
+    $this->alice = User::factory()->create([
+        'name' => 'Alice Liddell',
+        'username' => 'alice',
+        'popname' => 'Down The Rabbit Hole',
+        'about' => 'Long-time member. Literature, philosophy, and the occasional tea party.',
+        'location' => 'Wonderland',
+        'favouriteMovie' => 'Pan\'s Labyrinth',
+        'favouriteMusic' => 'Kate Bush, Joanna Newsom',
+    ]);
+
+    $this->bob = User::factory()->create([
+        'name' => 'Bob Hoskins',
+        'username' => 'bob',
+        'popname' => 'It\'s Good To Talk',
+        'about' => 'Film fan and amateur chef.',
+        'location' => 'London',
+        'favouriteMovie' => 'The Long Good Friday',
+        'favouriteMusic' => 'The Clash',
+    ]);
+
+    // The person whose perspective all screenshots are taken from.
+    // Plain member — no moderator role anywhere.
+    $this->viewer = User::factory()->create([
+        'name' => 'Charlie Bucket',
+        'username' => 'charlie',
+        'popname' => 'Golden Ticket',
+        'about' => 'New member, big fan of films and cooking.',
+        'location' => 'Loompaland (formerly)',
+        'password' => Hash::make('password'),
+    ]);
+
+    // Section tree — moderated by alice and bob, not viewer
+    $this->home = Section::factory()->for($this->alice, 'moderator')->create([
+        'parent_id' => null,
+        'title' => 'The Lounge',
+        'intro' => 'The main hub. All conversations start here.',
+    ]);
+
+    $this->subSection = Section::factory()
+        ->for($this->bob, 'moderator')
+        ->for($this->home, 'parent')
+        ->create([
+            'title' => 'General Chat',
+            'intro' => 'Anything and everything. No rules except be kind.',
+        ]);
+
+    $this->techSection = Section::factory()
+        ->for($this->alice, 'moderator')
+        ->for($this->home, 'parent')
+        ->create([
+            'title' => 'Tech Talk',
+            'intro' => 'Gadgets, code, and the internet of things.',
+        ]);
+
+    // A topic with rich posts — the viewer is subscribed here with older read progress
+    $this->topic = Topic::factory()
+        ->for($this->subSection, 'section')
+        ->create([
+            'title' => 'Welcome to Nexus — introduce yourself!',
+            'intro' => 'Tell us who you are and what brings you here.',
+        ]);
+
+    // Posts visible to the viewer (written before their last-read time)
+    $this->richPost = Post::factory()
+        ->for($this->topic)
+        ->for($this->alice, 'author')
+        ->create([
+            'title' => 'Hello everyone — Alice here!',
+            'text' => implode("\n\n", [
+                "Delighted to be here. I've been lurking for a while but finally decided to post.",
+                "A few things about me:\n\n- Big fan of **Lewis Carroll** and surreal fiction\n- Amateur photographer (film, not digital)\n- I make a very good Victoria sponge",
+                "> \"Curiouser and curiouser!\" — Alice's Adventures in Wonderland",
+                "Here's a picture that sums up my general outlook on life:",
+                "![A curious cat](https://upload.wikimedia.org/wikipedia/commons/thumb/1/1e/Sleeping_cat_on_her_back.jpg/640px-Sleeping_cat_on_her_back.jpg)",
+                "If you want to chat, feel free to drop me a [private message](/chat/).",
+            ]),
+            'popname' => 'Down The Rabbit Hole',
+            'time' => now()->subHours(5),
+        ]);
+
+    Post::factory()
+        ->for($this->topic)
+        ->for($this->bob, 'author')
+        ->create([
+            'title' => 'Re: Hello everyone!',
+            'text' => implode("\n\n", [
+                "@alice — wonderful to meet you! I've been here for years and the community is brilliant.",
+                "> Big fan of Lewis Carroll and surreal fiction",
+                "Same! Have you read _The Annotated Alice_ by Martin Gardner? Absolutely worth it.",
+                "Also — Victoria sponge _or_ coffee cake? That's the real question.",
+            ]),
+            'popname' => 'It\'s Good To Talk',
+            'time' => now()->subHours(4),
+        ]);
+
+    // Subscribe viewer and mark them as having read up to 3 hours ago
+    ViewHelper::subscribeToTopic($this->viewer, $this->topic);
+    $view = \App\Models\View::where('topic_id', $this->topic->id)
+        ->where('user_id', $this->viewer->id)
+        ->first();
+    if ($view) {
+        $view->latest_view_date = now()->subHours(3);
+        $view->save();
+    }
+
+    // Unread post — posted after the viewer's last-read time
+    $this->unreadPost = Post::factory()
+        ->for($this->topic)
+        ->for($this->alice, 'author')
+        ->create([
+            'title' => 'Coffee cake, obviously',
+            'text' => "Charlie! Welcome aboard. Coffee cake wins every time. Fight me.\n\n- Chandler Bing would agree\n- Joey would eat both",
+            'popname' => 'Down The Rabbit Hole',
+            'time' => now()->subHour(),
+        ]);
+
+    // A second topic with an unread post so Latest view shows more activity
+    $this->techTopic = Topic::factory()
+        ->for($this->techSection, 'section')
+        ->create([
+            'title' => 'Favourite tools and apps of 2025',
+            'intro' => 'Share the software that\'s made your year.',
+        ]);
+
+    ViewHelper::subscribeToTopic($this->viewer, $this->techTopic);
+    $techView = \App\Models\View::where('topic_id', $this->techTopic->id)
+        ->where('user_id', $this->viewer->id)
+        ->first();
+    if ($techView) {
+        $techView->latest_view_date = now()->subDays(2);
+        $techView->save();
+    }
+
+    Post::factory()
+        ->for($this->techTopic)
+        ->for($this->bob, 'author')
+        ->create([
+            'title' => 'Still using Obsidian daily',
+            'text' => implode("\n\n", [
+                "Two years in and I still open **Obsidian** before anything else in the morning.",
+                "My setup:\n\n- Daily notes with a template\n- Dataview for tracking reading progress\n- Canvas for planning larger projects",
+                "Honourable mentions: _Raycast_, _Tot_, and the humble `grep` command.",
+            ]),
+            'popname' => 'It\'s Good To Talk',
+            'time' => now()->subDay(),
+        ]);
+
+    // Profile comments on alice and bob so their profiles look lived-in
+    Comment::factory()->create([
+        'user_id' => $this->alice->id,
+        'author_id' => $this->bob->id,
+        'text' => 'Coffee cake. Always coffee cake.',
+    ]);
+
+    Comment::factory()->create([
+        'user_id' => $this->alice->id,
+        'author_id' => $this->viewer->id,
+        'text' => 'Love the photography work, Alice!',
+    ]);
+
+    Comment::factory()->create([
+        'user_id' => $this->bob->id,
+        'author_id' => $this->alice->id,
+        'text' => 'Great to finally see you posting! Long overdue.',
+    ]);
+
+    // A private conversation between viewer and alice with several messages
+    $this->chat = Chat::create([
+        'owner_id' => $this->viewer->id,
+        'partner_id' => $this->alice->id,
+        'is_read' => true,
+    ]);
+
+    foreach ([
+        [$this->alice->id,  "Hi Charlie! Saw your intro post — welcome aboard. How did you find us?"],
+        [$this->viewer->id, "Thanks Alice! A friend mentioned it. Been lurking for a while before I plucked up the courage to post."],
+        [$this->alice->id,  "Ha, we all do that. The community is really lovely once you get into it. Are you into films as well as cooking?"],
+        [$this->viewer->id, "Both! Though my cooking is much better than my film taste. I'll watch anything with a decent soundtrack."],
+        [$this->alice->id,  "That's the right approach. You'd get on well with Bob — he's the film expert around here."],
+        [$this->viewer->id, "I'll drop him a message. Thanks for the intro 😊"],
+    ] as [$sender, $text]) {
+        ChatMessage::create([
+            'chat_id'     => $this->chat->id,
+            'sender_id'   => $sender,
+            'message_text' => $text,
+        ]);
+    }
+
+    // -----------------------------------------------------------------------
+    // Notification state — three pending notifications for the viewer:
+    //   1. An unread profile comment (comment.read = false)
+    //   2. An @mention in a post
+    //   3. An incoming unread chat from alice (alice owns, viewer is partner)
+    // -----------------------------------------------------------------------
+
+    // 1. Unread comment on the viewer's own profile
+    Comment::factory()->create([
+        'user_id'   => $this->viewer->id,
+        'author_id' => $this->alice->id,
+        'text'      => 'Great first post Charlie — love the bit about soundtracks!',
+        'read'      => false,
+    ]);
+
+    // 2. @mention — alice mentions charlie in a post
+    $mentionPost = Post::factory()
+        ->for($this->topic)
+        ->for($this->alice, 'author')
+        ->create([
+            'title' => 'Speaking of films…',
+            'text'  => "@charlie — you'd love this one. Have you seen _Spirited Away_?",
+            'popname' => 'Down The Rabbit Hole',
+            'time'  => now()->subMinutes(10),
+        ]);
+
+    $mention = new Mention;
+    $mention->user_id = $this->viewer->id;
+    $mention->post_id = $mentionPost->id;
+    $mention->save();
+
+    // 3. Incoming unread chat — alice sent a follow-up message
+    $incomingChat = Chat::create([
+        'owner_id'  => $this->alice->id,
+        'partner_id' => $this->viewer->id,
+        'is_read'   => false,
+    ]);
+
+    foreach ([
+        [$this->alice->id,  "PS — Bob says hi too. You'll fit right in here 😊"],
+        [$this->alice->id,  "Also: there's a film night thread in Tech Talk you might enjoy."],
+    ] as [$sender, $text]) {
+        ChatMessage::create([
+            'chat_id'      => $incomingChat->id,
+            'sender_id'    => $sender,
+            'message_text' => $text,
+        ]);
+    }
+
+    // Active BBS mode — provides the welcome text shown on the login screen.
+    // The AddBBSModeToView middleware caches this as 'bbs_mode', so we flush
+    // the cache entry after creating it to ensure the middleware picks it up.
+    $theme = Theme::firstOrFail();
+    Mode::create([
+        'name'     => 'Default',
+        'theme_id' => $theme->id,
+        'active'   => true,
+        'override' => false,
+        'welcome'  => implode("\n\n", [
+            "## Welcome to Nexus",
+            "Nexus has been running since 2001, which makes it positively ancient by internet standards. We're a small, friendly community of long-term members.",
+            "**New here?** Introduce yourself in [General Chat](/section/latest/) and say hello.",
+            "> _\"The internet is not something you just dump something on. It's not a big truck.\"_ — Ted Stevens",
+            "To join, ask an existing member to send you an invite, or contact the admin at the address below.",
+        ]),
+    ]);
+    Cache::forget('bbs_mode');
+});
+
+test('01 login page', function () {
+    $page = visit('/login');
+    snap($page, '01-login-page');
+});
+
+test('02 home section listing', function () {
+    actingAs($this->viewer);
+
+    $page = visit('/');
+    snap($page, '02-home-section-listing');
+});
+
+test('03 sub-section with topics', function () {
+    actingAs($this->viewer);
+
+    $page = visit('/section/' . $this->subSection->id);
+    snap($page, '03-section-with-topics');
+});
+
+test('04 reading a topic with posts', function () {
+    actingAs($this->viewer);
+
+    $page = visit('/topic/' . $this->topic->id)->resize(1280, 900);
+    $page->screenshot(true, '04-reading-a-topic-desktop');
+    $page->resize(390, 844);
+    $page->script('window.scrollTo(0, 0)');
+    $page->wait(0.1)->screenshot(false, '04-reading-a-topic-mobile');
+});
+
+test('05 post compose form', function () {
+    actingAs($this->viewer);
+
+    $page = visit('/topic/' . $this->topic->id)->resize(1280, 900);
+    $page->script('window.scrollTo(0, document.body.scrollHeight)');
+    $page->wait(0.3)->screenshot(false, '05-post-compose-form-desktop');
+
+    $page->resize(390, 844);
+    $page->script('window.scrollTo(0, document.body.scrollHeight)');
+    $page->wait(0.3)->screenshot(false, '05-post-compose-form-mobile');
+});
+
+test('06 formatting help popover', function () {
+    actingAs($this->viewer);
+
+    // Popover appears on md+ screens only
+    $page = visit('/topic/' . $this->topic->id)->resize(1280, 900);
+    $page->script('window.scrollTo(0, document.body.scrollHeight)');
+    $page->wait(0.3)
+        ->click('a[data-bs-toggle="popover"]')
+        ->wait(0.5)
+        ->screenshot(false, '06-formatting-help-popover-desktop');
+
+    // On mobile the help is in a collapsible instead — open it
+    $page->resize(390, 844);
+    $page->script('window.scrollTo(0, document.body.scrollHeight)');
+    $page->wait(0.3)
+        ->click('a[data-bs-toggle="collapse"]')
+        ->wait(0.5)
+        ->screenshot(false, '06-formatting-help-collapse-mobile');
+});
+
+test('07 post preview tab', function () {
+    actingAs($this->viewer);
+
+    $page = visit('/topic/' . $this->topic->id)
+        ->resize(1280, 900)
+        ->type('[wire\\:model="title"]', 'Just joined — hello!')
+        ->type('[wire\\:model="text"]', "Hi everyone! So glad to be here.\n\n> Coffee cake, obviously\n\nHa! I'll bring biscuits.\n\nAlso: **bold**, _italic_, and here's a link [to my favourite site](https://example.com).")
+        ->click('#profile-tab')
+        ->wait(0.6);
+    $page->script('window.scrollTo(0, document.body.scrollHeight)');
+    $page->wait(0.2)->screenshot(false, '07-post-preview-desktop');
+
+    $page->resize(390, 844);
+    $page->script('window.scrollTo(0, document.body.scrollHeight)');
+    $page->wait(0.2)->screenshot(false, '07-post-preview-mobile');
+});
+
+test('08 editing an existing post', function () {
+    // Edit controls appear inline for the most recent post within 300 s
+    $freshPost = Post::factory()
+        ->for($this->topic)
+        ->for($this->viewer, 'author')
+        ->create([
+            'title' => 'Just joined — hello!',
+            'text' => "Hi everyone! So glad to be here. Quick typo to fix…",
+            'popname' => 'Golden Ticket',
+            'time' => now(),
+        ]);
+
+    actingAs($this->viewer);
+
+    $page = visit('/topic/' . $this->topic->id)->resize(1280, 900);
+    $page->screenshot(true, '08-editing-a-post-desktop');
+    $page->resize(390, 844);
+    $page->script('window.scrollTo(0, 0)');
+    $page->wait(0.1)->screenshot(false, '08-editing-a-post-mobile');
+});
+
+test('09 user profile — another member', function () {
+    actingAs($this->viewer);
+
+    $page = visit('/users/' . $this->alice->username)->resize(1280, 900);
+    $page->screenshot(true, '09-user-profile-desktop');
+    $page->resize(390, 844);
+    $page->script('window.scrollTo(0, 0)');
+    $page->wait(0.1)->screenshot(false, '09-user-profile-mobile');
+});
+
+test('10 adding a comment on a user profile', function () {
+    actingAs($this->viewer);
+
+    $page = visit('/users/' . $this->alice->username)
+        ->resize(1280, 900)
+        ->type('input[name="text"]', 'Love the cat photo, Alice!');
+    snap($page, '10-adding-profile-comment');
+});
+
+test('11 own profile page', function () {
+    actingAs($this->viewer);
+
+    $page = visit('/users/' . $this->viewer->username)->resize(1280, 900);
+    $page->screenshot(true, '11-own-profile-desktop');
+    $page->resize(390, 844);
+    $page->script('window.scrollTo(0, 0)');
+    $page->wait(0.1)->screenshot(false, '11-own-profile-mobile');
+});
+
+test('12 users list', function () {
+    actingAs($this->viewer);
+
+    $page = visit('/users/');
+    snap($page, '12-users-list');
+});
+
+test('13 search interface', function () {
+    actingAs($this->viewer);
+
+    $page = visit('/search');
+    snap($page, '13-search-interface');
+});
+
+test('14 search results for a keyword', function () {
+    actingAs($this->viewer);
+
+    $page = visit('/search/' . rawurlencode('coffee cake'));
+    snap($page, '14-search-keyword-results');
+});
+
+test('15 search results for an exact phrase', function () {
+    actingAs($this->viewer);
+
+    $page = visit('/search/' . rawurlencode('"Lewis Carroll"'));
+    snap($page, '15-search-phrase-results');
+});
+
+test('16 latest unread topics', function () {
+    actingAs($this->viewer);
+
+    $page = visit('/section/latest');
+    snap($page, '16-latest-unread-topics');
+});
+
+test('17 private chat — conversation loaded', function () {
+    actingAs($this->viewer);
+
+    // Select alice from the dropdown so the existing conversation is shown
+    $page = visit('/chat/')
+        ->resize(1280, 900)
+        ->select('#usersDropdown', $this->alice->id)
+        ->wait(0.8);
+    snap($page, '17-chat-with-conversation');
+});
+
+test('18 private chat — composing a reply', function () {
+    actingAs($this->viewer);
+
+    $page = visit('/chat/')
+        ->resize(1280, 900)
+        ->select('#usersDropdown', $this->alice->id)
+        ->wait(0.8)
+        ->type('@chat-input', 'Will do — thanks again for the warm welcome!')
+        ->screenshot(false, '18-chat-composing-reply-desktop');
+
+    $page->resize(390, 844);
+    $page->script('window.scrollTo(0, 0)');
+    $page->wait(0.1)->screenshot(false, '18-chat-composing-reply-mobile');
+});
+
+// -----------------------------------------------------------------------
+// Notification screenshots
+// -----------------------------------------------------------------------
+
+test('19 notifications — toolbar badge and profile dropdown', function () {
+    actingAs($this->viewer);
+
+    // Desktop: profile menu dropdown shows comment + chat badges
+    $page = visit('/')
+        ->resize(1280, 900)
+        ->wait(0.5)
+        ->click('#profiledropdown')
+        ->wait(0.3)
+        ->screenshot(false, '19-notifications-profile-dropdown-desktop');
+
+    // Mobile: hamburger has notification badge; open the menu to show it
+    $page->resize(390, 844);
+    $page->script('window.scrollTo(0, 0)');
+    $page->wait(0.1)
+        ->click('.navbar-toggler')
+        ->wait(0.3)
+        ->screenshot(false, '19-notifications-toolbar-mobile');
+});
+
+test('20 notifications — mentions bell dropdown', function () {
+    actingAs($this->viewer);
+
+    // The bell alert icon only appears when mentions exist
+    $page = visit('/')
+        ->resize(1280, 900)
+        ->wait(0.5)
+        ->click('[dusk="mentions-menu-toggle"]')
+        ->wait(0.3)
+        ->screenshot(false, '20-notifications-mentions-dropdown-desktop');
+
+    // Mobile: open the hamburger menu first so the bell is visible
+    $page->resize(390, 844);
+    $page->script('window.scrollTo(0, 0)');
+    $page->wait(0.1)
+        ->click('.navbar-toggler')
+        ->wait(0.3)
+        ->screenshot(false, '20-notifications-mentions-mobile');
+});
+
+test('21 notifications — viewing the profile comment', function () {
+    actingAs($this->viewer);
+
+    // Own profile page — unread comment from alice is visible
+    $page = visit('/users/' . $this->viewer->username)->resize(1280, 900);
+    $page->screenshot(true, '21-notifications-profile-comment-desktop');
+
+    $page->resize(390, 844);
+    $page->script('window.scrollTo(0, 0)');
+    $page->wait(0.1)->screenshot(false, '21-notifications-profile-comment-mobile');
+});
+
+test('22 notifications — viewing an unread chat message', function () {
+    actingAs($this->viewer);
+
+    // The chat page — unread message from alice is loaded
+    $page = visit('/chat/')
+        ->resize(1280, 900)
+        ->select('#usersDropdown', $this->alice->id)
+        ->wait(0.8);
+    snap($page, '22-notifications-unread-chat');
+});


### PR DESCRIPTION
## Summary

- Adds `tests/Browser/ScreenshotTourTest.php` — 22 Playwright tests producing paired desktop (1280×900) and mobile (390×844) screenshots of all main user journeys
- Covers: login page (with welcome text), section/topic browsing, reading posts, composing and editing posts, NxCode formatting help, user profiles and comments, search, private chat, and three notification states (comment badge, @mention bell, unread chat message)
- Screenshots are taken as a normal member with no moderator/admin privileges
- Excluded from the default `Browser` testsuite in `phpunit.xml` so it doesn't run with `sail test` — must be run explicitly

## How to run

```bash
sail php vendor/bin/pest --browser chrome tests/Browser/ScreenshotTourTest.php
```

Output lands in `tests/Browser/Screenshots/` (gitignored).

## Purpose

The screenshots are intended for use with Claude Design to evaluate and improve the UI — particularly around post formatting, inline editing, and notification flows, which can feel opaque to new users.

## Also included

- `CLAUDE.md` version updates (PHP 8.4, Laravel v13, Livewire v4, Pest v4) from the prior tech-debt sprint
- `boost.json` skill config and `.ai/skills/technical-debt-manager-php-laravel/` skill definition

## Test plan

- [ ] Run the screenshot tour and confirm 44 images are produced in `tests/Browser/Screenshots/`
- [ ] Confirm `sail test` and `sail php vendor/bin/pest --browser chrome tests/Browser/` do NOT run `ScreenshotTourTest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)